### PR TITLE
Fix security warnings on GitHub Actions

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -3,6 +3,11 @@ name: ♻️ Sync Labels
 on:
   workflow_dispatch:
 
+# Default permissions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   labels:
     name: ♻️ Sync labels


### PR DESCRIPTION
# Changes
- label-sync.yml:
  - add (explicit) default permissions:
    - contents: read
    - pull-requests: write

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Configured default permissions in the GitHub Actions workflow: repository contents set to read and pull requests set to write.
  - Added a clarifying comment preceding the permissions block.
  - No changes to workflow triggers, jobs, or steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->